### PR TITLE
Horizon-9: Check if user is already logged in from a previous session.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import './App.css';
+import { authenticatedUserLoginId } from './authentication/user';
+
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 import HomePage from './components/home/home_page';
@@ -10,7 +12,7 @@ import SessionsSelectPage from './components/sessions/sessions_selection_page';
 import SiteNavigationBar from './components/site/navigation_bar';
 import SiteFooter from './components/site/footer';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { Container, Row } from 'react-bootstrap';
@@ -19,6 +21,15 @@ function App() {
   const navigate = useNavigate();
 
   const [userName, setUserName] = useState('');
+
+  useEffect(() => {
+      const setLoginId = async () => {
+        setUserName(await authenticatedUserLoginId() ?? '');
+      };
+
+      setLoginId();
+    },
+    [setUserName]);
 
   function isUserLoggedIn(): boolean {
     return !!userName;

--- a/src/authentication/user.ts
+++ b/src/authentication/user.ts
@@ -1,0 +1,15 @@
+import { getCurrentUser } from 'aws-amplify/auth';
+
+export async function authenticatedUserLoginId(): Promise<string | undefined> {
+  try {
+    const result = await getCurrentUser();
+
+    return result.signInDetails?.loginId;
+  } catch(error) {
+    return undefined;
+  }
+}
+
+export async function isAuthenticatedUserLoggedIn(): Promise<boolean> {
+  return await authenticatedUserLoginId() !== undefined;
+}

--- a/src/components/home/home_page.tsx
+++ b/src/components/home/home_page.tsx
@@ -53,7 +53,6 @@ export function HomePage(props: PageProperties) {
       {props.isUserLoggedIn() && (
         <Link
           to="/sessions/select"
-          state={{ isUserLoggedIn: props.isUserLoggedIn }}
         >
           <Button variant="primary" >Select Sessions</Button>
         </Link>


### PR DESCRIPTION
AWS Amplify stores the authenticated user credentials in the browser's cache for a given period of time or until they explicitly logged-out.

In the case, in which the user has logged in and uses the application, then to exit the browser, then when opening the cloud application the user can continue using the application without having to login.

This is to fix the situation in which the login of a user account fails since a user is already logged in.